### PR TITLE
Add /countstatus command

### DIFF
--- a/api/app.js
+++ b/api/app.js
@@ -203,11 +203,10 @@ app.event('message', async (body) => {
 
 app.command('/countstatus', async ({ command, ack, respond }) => {
 	await ack()
-	const { text, user_id } = command
 	const channel = 'CDJMS683D'
 
-	let oldest = await fetchOldest(channel);
-	let latest = await fetchLatest(channel);
+	let oldest = await fetchOldest(channel)
+	let latest = await fetchLatest(channel)
 
 	await respond({
 		text: `The day's current progress is *${latest - oldest}*!`,

--- a/api/app.js
+++ b/api/app.js
@@ -201,6 +201,20 @@ app.event('message', async (body) => {
 	}
 });
 
+app.command('/countstatus', async ({ command, ack, respond }) => {
+	await ack()
+	const { text, user_id } = command
+	const channel = 'CDJMS683D'
+
+	let oldest = await fetchOldest(channel);
+	let latest = await fetchLatest(channel);
+
+	await respond({
+		text: `The day's current progress is *${latest - oldest}*!`,
+		response_type: 'ephemeral'
+	})
+});
+
 (async (req, res) => {
 	// Start your app
 	try {


### PR DESCRIPTION
Sometimes I'm curious to see what the current status for today is, and I don't want to scroll up and find it myself. This adds a `/countstatus` command, which calculates it for you and responds ephemerally.

Notes:

* I'm pretty sure this code will work, but it's completely untested
* In order to make the command work, you'll need to register this command in the Slack app directory for Million Stats, and point the url to `url-where-million-stats-is-hosted/slack/events`